### PR TITLE
cleanup: CI checks, make lint

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,55 @@
+name: Checks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.23
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run unit tests and generate the coverage report
+        run: make test-race
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.23
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Install gofumpt
+        run: go install mvdan.cc/gofumpt@v0.4.0
+
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+
+      - name: Lint
+        run: make lint
+
+      - name: Ensure go mod tidy runs without changes
+        run: |
+          go mod tidy
+          git update-index -q --really-refresh
+          git diff-index HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /constellation/
 /cvm-reverse-proxy
 /measurements.json
+/build/

--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,19 @@ build-proxy-server:
 
 .PHONY: test
 test:
-	go test ./...
+	go test ./cmd/... ./common/... ./proxy/...
 
 .PHONY: test-race
 test-race:
-	go test -race ./...
+	go test -race ./cmd/... ./common/... ./proxy/...
 
 .PHONY: lint
 lint:
 	gofmt -d -s cmd common proxy
 	gofumpt -d -extra cmd common proxy
 	go vet ./cmd/... ./common/... ./proxy/...
-	# staticcheck ./... // complains about 1.22.4
-	golangci-lint run --exclude-dirs internal
-	# nilaway ./cmd/... ./common/... ./proxy/... // incorrect findings
+	staticcheck ./cmd/... ./common/... ./proxy/...
+	# golangci-lint run --exclude-dirs internal --exclude-dirs-use-default=false
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,12 @@ cover-html: ## Run tests with coverage and open the HTML report
 	go test -coverprofile=/tmp/go-sim-lb.cover.tmp ./...
 	go tool cover -html=/tmp/go-sim-lb.cover.tmp
 	unlink /tmp/go-sim-lb.cover.tmp
+
+.PHONY: docker-images
+docker-images: ## Build the Docker images
+	DOCKER_BUILDKIT=1 docker build \
+		--platform linux/amd64 \
+		--build-arg VERSION=${VERSION} \
+		--file proxy-server.dockerfile \
+		--tag cvm-proxy-server \
+	.

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,50 @@
+# Heavily inspired by Lighthouse: https://github.com/sigp/lighthouse/blob/stable/Makefile
+# and Reth: https://github.com/paradigmxyz/reth/blob/main/Makefile
+.DEFAULT_GOAL := help
+
 VERSION := $(shell git describe --tags --always --dirty="-dev")
 
-.PHONY: all
-all: clean build-proxy-client build-proxy-server
+##@ Help
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: v
-v:
+v: ## Show the version
 	@echo "Version: ${VERSION}"
 
+##@ Build
+
 .PHONY: clean
-clean:
+clean: ## Clean the build directory
 	rm -rf build/
 
+.PHONY: build
+build: clean build-proxy-client build-proxy-server ## Build the proxy client and server
+
 .PHONY: build-proxy-client
-build-proxy-client:
+build-proxy-client: ## Build the proxy client
 	@mkdir -p ./build
 	go build -trimpath -ldflags "-X cvm-reverse-proxy/common.Version=${VERSION}" -v -o ./build/proxy-client cmd/proxy-client/main.go
 
 .PHONY: build-proxy-server
-build-proxy-server:
+build-proxy-server: ## Build the proxy server
 	@mkdir -p ./build
 	go build -trimpath -ldflags "-X cvm-reverse-proxy/common.Version=${VERSION}" -v -o ./build/proxy-server cmd/proxy-server/main.go
 
+##@ Test & Development
+
 .PHONY: test
-test:
+test: ## Run tests
 	go test ./cmd/... ./common/... ./proxy/...
 
 .PHONY: test-race
-test-race:
+test-race: ## Run tests with race detector
 	go test -race ./cmd/... ./common/... ./proxy/...
 
 .PHONY: lint
-lint:
+lint: ## Run linters
 	gofmt -d -s cmd common proxy
 	gofumpt -d -extra cmd common proxy
 	go vet ./cmd/... ./common/... ./proxy/...
@@ -38,27 +52,27 @@ lint:
 	# golangci-lint run --exclude-dirs internal --exclude-dirs-use-default=false
 
 .PHONY: fmt
-fmt:
+fmt: ## Format the code
 	gofmt -s -w cmd common proxy
 	gci write cmd common proxy
 	gofumpt -w -extra cmd common proxy
 	go mod tidy
 
 .PHONY: gofumpt
-gofumpt:
+gofumpt: ## Run gofumpt
 	gofumpt -l -w -extra cmd common proxy
 
-.PHONY: lt
+.PHONY: lt ## Alias for lint and test
 lt: lint test
 
 .PHONY: cover
-cover:
+cover: ## Run tests with coverage
 	go test -coverprofile=/tmp/go-sim-lb.cover.tmp ./...
 	go tool cover -func /tmp/go-sim-lb.cover.tmp
 	unlink /tmp/go-sim-lb.cover.tmp
 
 .PHONY: cover-html
-cover-html:
+cover-html: ## Run tests with coverage and open the HTML report
 	go test -coverprofile=/tmp/go-sim-lb.cover.tmp ./...
 	go tool cover -html=/tmp/go-sim-lb.cover.tmp
 	unlink /tmp/go-sim-lb.cover.tmp

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This application provides a reverse proxy with TLS termination, supporting confi
 
 - Client-side TLS termination with confidentialVM attestation verification.
 - Server-side TLS termination with confidentialVM attestation verification.
-- Mutual attestations between client and server.
 - Reverse proxy functionality to forward requests between client and server.
 
 Both the client-side and the server-side TLS termination can be separately configured to provide attestations and verify attestations.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This application provides a reverse proxy with TLS termination, supporting confi
 
 - Client-side TLS termination with confidentialVM attestation verification.
 - Server-side TLS termination with confidentialVM attestation verification.
+- Mutual attestations between client and server.
 - Reverse proxy functionality to forward requests between client and server.
 
 Both the client-side and the server-side TLS termination can be separately configured to provide attestations and verify attestations.

--- a/cmd/proxy-client/main.go
+++ b/cmd/proxy-client/main.go
@@ -8,6 +8,7 @@ import (
 	"cvm-reverse-proxy/common"
 	"cvm-reverse-proxy/internal/atls"
 	"cvm-reverse-proxy/proxy"
+
 	"github.com/urfave/cli/v2" // imports as package "cli"
 )
 
@@ -53,7 +54,7 @@ func main() {
 		Name:   "proxy-client",
 		Usage:  "Serve API, and metrics",
 		Flags:  flags,
-		Action: run_client,
+		Action: runClient,
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -61,7 +62,7 @@ func main() {
 	}
 }
 
-func run_client(cCtx *cli.Context) error {
+func runClient(cCtx *cli.Context) error {
 	listenAddr := cCtx.String("listen-addr")
 	targetAddr := cCtx.String("target-addr")
 	serverMeasurements := cCtx.String("server-measurements")

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -13,6 +13,7 @@ import (
 	"cvm-reverse-proxy/common"
 	"cvm-reverse-proxy/internal/atls"
 	"cvm-reverse-proxy/proxy"
+
 	"github.com/urfave/cli/v2" // imports as package "cli"
 )
 
@@ -58,7 +59,7 @@ func main() {
 		Name:   "proxy-server",
 		Usage:  "Serve API, and metrics",
 		Flags:  flags,
-		Action: run_server,
+		Action: runServer,
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -66,7 +67,7 @@ func main() {
 	}
 }
 
-func run_server(cCtx *cli.Context) error {
+func runServer(cCtx *cli.Context) error {
 	listenAddr := cCtx.String("listen-addr")
 	targetAddr := cCtx.String("target-addr")
 	clientMeasurements := cCtx.String("client-measurements")

--- a/common/logging.go
+++ b/common/logging.go
@@ -1,3 +1,4 @@
+// Package common contains shared utilities
 package common
 
 import (

--- a/proxy-server.dockerfile
+++ b/proxy-server.dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+FROM golang:1.23 AS builder
+ARG VERSION
+WORKDIR /build
+ADD go.mod /build/
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux \
+       go mod download
+ADD . /build/
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=linux \
+    go build \
+        -trimpath \
+        -ldflags "-s -X main.version=${VERSION}" \
+        -v \
+        -o proxy-server \
+    cmd/proxy-server/main.go
+
+FROM alpine:latest
+WORKDIR /app
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /build/proxy-server /app/proxy-server
+ENV LISTEN_ADDR=":8080"
+EXPOSE 8080
+CMD ["/app/proxy-server"]

--- a/proxy/atls_config.go
+++ b/proxy/atls_config.go
@@ -87,7 +87,7 @@ func ExtractMeasurementsFromExtension(ext *pkix.Extension, v variant.Variant) (m
 		}
 		return measurements, nil
 	default:
-		return nil, errors.New("unsupported ATLS variant!")
+		return nil, errors.New("unsupported ATLS variant")
 	}
 }
 

--- a/proxy/atls_config.go
+++ b/proxy/atls_config.go
@@ -1,3 +1,4 @@
+// Package proxy contains the core proxy functionality and aTLS configuration
 package proxy
 
 import (

--- a/proxy/mutli_validator.go
+++ b/proxy/mutli_validator.go
@@ -7,7 +7,7 @@ import (
 	"cvm-reverse-proxy/internal/atls"
 )
 
-// Validator for Azure confidential VM attestation using TDX which accepts multiple measurements
+// MultiValidator is a validator for Azure confidential VM attestation using TDX which accepts multiple measurements
 type MultiValidator struct {
 	oid        asn1.ObjectIdentifier
 	validators []atls.Validator


### PR DESCRIPTION
- Added CI checks (`make lint` and `make test`)
- Fixed linting errors
- Nice `make` output that shows all commands
- Initial cvm-proxy-server Dockerfile

Sadly, I couldn't make `golangci-lint` work right away, it errors with this message:

```
$ golangci-lint run --exclude-dirs internal
WARN [runner] Can't run linter goanalysis_metalinter: buildir: failed to load package internal: could not load export data: no export data for "github.com/google/go-tpm-tools/simulator/internal" 
ERRO Running error: can't run linter goanalysis_metalinter
buildir: failed to load package internal: could not load export data: no export data for "github.com/google/go-tpm-tools/simulator/internal" 
```

keeping golangci-lint for a later PR

---

Output from `make`:

![Screenshot 2024-10-02 at 12 58 26](https://github.com/user-attachments/assets/0a2e0ca3-d28d-4f52-a6c3-c947815f411c)


