### PR TITLE
Adds an option to serve and verify regular TLS

### DIFF
--- a/cmd/proxy-client/main.go
+++ b/cmd/proxy-client/main.go
@@ -29,6 +29,10 @@ var flags []cli.Flag = []cli.Flag{
 		Value: string(proxy.AttestationAzureTDX),
 		Usage: "type of attestation to expect and verify (" + proxy.AvailableAttestationTypes + ")",
 	},
+	&cli.StringFlag{
+		Name:  "server-measurements",
+		Usage: "optional path to JSON measurements enforced on the server",
+	},
 	&cli.BoolFlag{
 		Name:  "verify-tls",
 		Value: false,
@@ -36,11 +40,7 @@ var flags []cli.Flag = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:  "tls-ca-certificate",
-		Usage: "Additional CA certificate to verify against (PEM) [default=no additional TLS certs]",
-	},
-	&cli.StringFlag{
-		Name:  "server-measurements",
-		Usage: "optional path to JSON measurements enforced on the server",
+		Usage: "additional CA certificate to verify against (PEM) [default=no additional TLS certs]. Only valid with --verify-tls.",
 	},
 	&cli.StringFlag{
 		Name:  "client-attestation-type",
@@ -126,7 +126,6 @@ func runClient(cCtx *cli.Context) error {
 	if verifyTLS {
 		tlsConfig.InsecureSkipVerify = false
 		tlsConfig.ServerName = ""
-		tlsConfig.VerifyPeerCertificate = nil // TODO: make sure this is needed
 	}
 
 	if additionalTLSCA := cCtx.String("tls-ca-certificate"); additionalTLSCA != "" {

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -142,20 +142,22 @@ func runServer(cCtx *cli.Context) error {
 			return err
 		}
 
-		originalGetConfigForClient := confTLS.GetConfigForClient
-		confTLS.GetConfigForClient = func(clientHello *tls.ClientHelloInfo) (*tls.Config, error) {
-			ogClientConfig, err := originalGetConfigForClient(clientHello)
-			if err != nil {
-				return ogClientConfig, err
-			}
+		atlsGetConfigForClient := confTLS.GetConfigForClient
 
-			// Note: we don't have to copy the certificate because it's always created per request
-			ogClientConfig.Certificates = []tls.Certificate{cert}
-			ogClientConfig.GetClientCertificate = nil
-			ogClientConfig.ServerName = ""
-			return ogClientConfig, nil
+		confTLS = &tls.Config{
+			GetConfigForClient: func(clientHello *tls.ClientHelloInfo) (*tls.Config, error) {
+				ogClientConfig, err := atlsGetConfigForClient(clientHello)
+				if err != nil {
+					return ogClientConfig, err
+				}
+
+				// Note: we don't have to copy the certificate because it's always created per request
+				ogClientConfig.Certificates = []tls.Certificate{cert}
+				ogClientConfig.GetCertificate = nil
+				return ogClientConfig, nil
+
+			},
 		}
-
 	}
 
 	// Create an HTTP server

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -34,17 +34,17 @@ var flags []cli.Flag = []cli.Flag{
 		Usage: "type of attestation to present (" + proxy.AvailableAttestationTypes + ")",
 	},
 	&cli.StringFlag{
-		Name:  "client-attestation-type",
-		Value: string(proxy.AttestationNone),
-		Usage: "type of attestation to expect and verify (" + proxy.AvailableAttestationTypes + ")",
-	},
-	&cli.StringFlag{
 		Name:  "tls-certificate",
-		Usage: "Certificate to present (PEM)",
+		Usage: "Certificate to present (PEM). Only valid for --server-attestation-type=none and with --tls-private-key.",
 	},
 	&cli.StringFlag{
 		Name:  "tls-private-key",
-		Usage: "Private key for the certificate (PEM)",
+		Usage: "Private key for the certificate (PEM). Only valid with --tls-certificate.",
+	},
+	&cli.StringFlag{
+		Name:  "client-attestation-type",
+		Value: string(proxy.AttestationNone),
+		Usage: "type of attestation to expect and verify (" + proxy.AvailableAttestationTypes + ")",
 	},
 	&cli.StringFlag{
 		Name:  "client-measurements",

--- a/cmd/proxy-server/main.go
+++ b/cmd/proxy-server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"log"
 	"net/http"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"github.com/flashbots/cvm-reverse-proxy/common"
 	"github.com/flashbots/cvm-reverse-proxy/internal/atls"
 	"github.com/flashbots/cvm-reverse-proxy/proxy"
-
 	"github.com/urfave/cli/v2" // imports as package "cli"
 )
 
@@ -37,6 +37,14 @@ var flags []cli.Flag = []cli.Flag{
 		Name:  "client-attestation-type",
 		Value: string(proxy.AttestationNone),
 		Usage: "type of attestation to expect and verify (" + proxy.AvailableAttestationTypes + ")",
+	},
+	&cli.StringFlag{
+		Name:  "tls-certificate",
+		Usage: "Certificate to present (PEM)",
+	},
+	&cli.StringFlag{
+		Name:  "tls-private-key",
+		Usage: "Private key for the certificate (PEM)",
 	},
 	&cli.StringFlag{
 		Name:  "client-measurements",
@@ -73,6 +81,10 @@ func runServer(cCtx *cli.Context) error {
 	clientMeasurements := cCtx.String("client-measurements")
 	logJSON := cCtx.Bool("log-json")
 	logDebug := cCtx.Bool("log-debug")
+	serverAttestationTypeFlag := cCtx.String("server-attestation-type")
+
+	certFile := cCtx.String("tls-certificate")
+	keyFile := cCtx.String("tls-private-key")
 
 	log := common.SetupLogger(&common.LoggingOpts{
 		Debug:   logDebug,
@@ -81,7 +93,18 @@ func runServer(cCtx *cli.Context) error {
 		Version: common.Version,
 	})
 
-	serverAttestationType, err := proxy.ParseAttestationType(cCtx.String("server-attestation-type"))
+	useRegularTLS := certFile != "" || keyFile != ""
+	if serverAttestationTypeFlag != "none" && useRegularTLS {
+		log.Error("invalid combination of --tls-certificate, --tls-private-key and --server-attestation-type flags passed (only 'none' is allowed)")
+		return errors.New("invalid combination of --tls-certificate, --tls-private-key and --server-attestation-type flags passed (only 'none' is allowed)")
+	}
+
+	if useRegularTLS && (certFile == "" || keyFile == "") {
+		log.Error("not all of --tls-certificate and --tls-private-key specified")
+		return errors.New("not all of --tls-certificate and --tls-private-key specified")
+	}
+
+	serverAttestationType, err := proxy.ParseAttestationType(serverAttestationTypeFlag)
 	if err != nil {
 		log.With("attestation-type", cCtx.String("server-attestation-type")).Error("invalid server-attestation-type passed, see --help")
 		return err
@@ -110,6 +133,29 @@ func runServer(cCtx *cli.Context) error {
 	confTLS, err := atls.CreateAttestationServerTLSConfig(issuer, validators)
 	if err != nil {
 		panic(err)
+	}
+
+	if useRegularTLS {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			log.Error("could not load tls key pair", "err", err)
+			return err
+		}
+
+		originalGetConfigForClient := confTLS.GetConfigForClient
+		confTLS.GetConfigForClient = func(clientHello *tls.ClientHelloInfo) (*tls.Config, error) {
+			ogClientConfig, err := originalGetConfigForClient(clientHello)
+			if err != nil {
+				return ogClientConfig, err
+			}
+
+			// Note: we don't have to copy the certificate because it's always created per request
+			ogClientConfig.Certificates = []tls.Certificate{cert}
+			ogClientConfig.GetClientCertificate = nil
+			ogClientConfig.ServerName = ""
+			return ogClientConfig, nil
+		}
+
 	}
 
 	// Create an HTTP server


### PR DESCRIPTION
Verified with curl, openssl and proxy-client
Also verified with no client attestation and with azure-tdx client attestation, the report is validated correctly