### PR TITLE
chore: Add reproducible build docker and github release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        binary: [proxy-client, proxy-server]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for git describe to work properly
+
+      # Add buildx setup
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdf50867830130cc04c4d1bb9de141d
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.binary }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          provenance: false  # Disable build metadata that could affect reproducibility
+          build-args: |
+            BINARY=${{ matrix.binary }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  KANIKO_VERSION: gcr.io/kaniko-project/executor@sha256:9e69fd4330ec887829c780f5126dd80edc663df6def362cd22e79bcdf00ac53f
 
 jobs:
   build-and-push:
@@ -24,22 +25,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Needed for git describe to work properly
+          fetch-depth: 0
 
-      # Add buildx setup
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          buildkitd-flags: --debug
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdf50867830130cc04c4d1bb9de141d
         with:
@@ -49,15 +37,21 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          provenance: false  # Disable build metadata that could affect reproducibility
-          build-args: |
-            BINARY=${{ matrix.binary }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and Push with Kaniko
+        run: |
+          mkdir -p /home/runner/.docker
+
+          echo '{"auths":{"${{ env.REGISTRY }}":{"auth":"'$(echo -n "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" | base64)'"}}}'> /home/runner/.docker/config.json
+
+          docker run \
+            -v ${{ github.workspace }}:/workspace \
+            -v /home/runner/.docker/config.json:/kaniko/.docker/config.json \
+            ${{ env.KANIKO_VERSION }} \
+            --context /workspace \
+            --dockerfile /workspace/Dockerfile \
+            --reproducible \
+            --cache=true \
+            --cache-repo ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-cache \
+            --build-arg BINARY=${{ matrix.binary }} \
+            --destination ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.binary }}:${{ steps.meta.outputs.version }} \
+            ${{ join(steps.meta.outputs.tags-csv | split(',') | map(format('--destination %s', @)), ' ') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.24rc2-bullseye@sha256:236da40764c1bcf469fcaf6ca225ca881c3f06cbd1934e392d6e4af3484f6cac AS builder
+
+ARG BINARY=proxy-client
+WORKDIR /app
+COPY ./ /app
+RUN make build-${BINARY}
+
+FROM gcr.io/distroless/cc-debian12:nonroot-6755e21ccd99ddead6edc8106ba03888cbeed41a
+ARG BINARY
+COPY --from=builder /app/build/${BINARY} /app
+ENTRYPOINT [ "/app" ]

--- a/Makefile
+++ b/Makefile
@@ -26,12 +26,12 @@ build: clean build-proxy-client build-proxy-server ## Build the proxy client and
 .PHONY: build-proxy-client
 build-proxy-client: ## Build the proxy client
 	@mkdir -p ./build
-	go build -trimpath -ldflags "-X github.com/flashbots/cvm-reverse-proxy/common.Version=${VERSION}" -v -o ./build/proxy-client cmd/proxy-client/main.go
+	go build -trimpath -ldflags "-s -w -buildid= -X github.com/flashbots/cvm-reverse-proxy/common.Version=${VERSION}" -v -o ./build/proxy-client cmd/proxy-client/main.go
 
 .PHONY: build-proxy-server
 build-proxy-server: ## Build the proxy server
 	@mkdir -p ./build
-	go build -trimpath -ldflags "-X github.com/flashbots/cvm-reverse-proxy/common.Version=${VERSION}" -v -o ./build/proxy-server cmd/proxy-server/main.go
+	go build -trimpath -ldflags "-s -w -buildid= -X github.com/flashbots/cvm-reverse-proxy/common.Version=${VERSION}" -v -o ./build/proxy-server cmd/proxy-server/main.go
 
 ##@ Test & Development
 


### PR DESCRIPTION
This PR does the following:
- adds Dockerfile to build a reproducible distroless image of the reverse proxy (server & client)
- adds github release workflow that runs two docker builds in parallel for both server and client and pushes the results to ghcr
- adds build flags for reproducible builds.


### Current open issue:
when rebuilding the docker image from scratch after clearing cache, it is not reproducing the same docker image hash/digest again. More investigations are necessary as not only the reproducible binary is necessary here but also the final image hash too.

**Update**: This is no longer an issue because now we adjusted the CI to use [kaniko](https://github.com/GoogleContainerTools/kaniko) to build the image reproducibly