### PR TITLE
[WIP] Allows specifying allowed measurements and target URL by headers

### DIFF
--- a/cmd/proxy-client/main.go
+++ b/cmd/proxy-client/main.go
@@ -4,11 +4,15 @@ import (
 	"crypto/x509"
 	"errors"
 	"log"
+	"log/slog"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
 
 	"github.com/flashbots/cvm-reverse-proxy/common"
 	"github.com/flashbots/cvm-reverse-proxy/internal/atls"
+	"github.com/flashbots/cvm-reverse-proxy/multimeasurements"
 	"github.com/flashbots/cvm-reverse-proxy/proxy"
 	"github.com/flashbots/cvm-reverse-proxy/tdx"
 	"github.com/urfave/cli/v2" // imports as package "cli"
@@ -65,6 +69,15 @@ var flags []cli.Flag = []cli.Flag{
 	},
 }
 
+type ClientConfig struct {
+	ListenAddr            string `json:"listen_addr"`
+	TargetAddr            string `json:"target_addr"`
+	ServerMeasurements    string `json:"server_measurements"`
+	VerifyTLS             bool   `json:"verify_tls"`
+	TLSCACertificate      string `json:"tls_ca_certificate"`
+	ClientAttestationType string `json:"client_attestation_type"`
+}
+
 func main() {
 	app := &cli.App{
 		Name:   "proxy-client",
@@ -79,18 +92,18 @@ func main() {
 }
 
 func runClient(cCtx *cli.Context) error {
-	listenAddr := cCtx.String("listen-addr")
-	targetAddr := cCtx.String("target-addr")
-	serverMeasurements := cCtx.String("server-measurements")
-	logJSON := cCtx.Bool("log-json")
-	logDebug := cCtx.Bool("log-debug")
-	tdx.SetLogDcapQuote(cCtx.Bool("log-dcap-quote"))
-
-	verifyTLS := cCtx.Bool("verify-tls")
+	config := ClientConfig{
+		ListenAddr:            cCtx.String("listen-addr"),
+		TargetAddr:            cCtx.String("target-addr"),
+		ServerMeasurements:    cCtx.String("server-measurements"),
+		VerifyTLS:             cCtx.Bool("verify-tls"),
+		TLSCACertificate:      cCtx.String("tls-ca-certificate"),
+		ClientAttestationType: cCtx.String("client-attestation-type"),
+	}
 
 	log := common.SetupLogger(&common.LoggingOpts{
-		Debug:   logDebug,
-		JSON:    logJSON,
+		Debug:   cCtx.Bool("log-debug"),
+		JSON:    cCtx.Bool("log-json"),
 		Service: "proxy-client",
 		Version: common.Version,
 	})
@@ -99,14 +112,20 @@ func runClient(cCtx *cli.Context) error {
 		log.Warn("DEPRECATED: --server-attestation-type is deprecated and will be removed in a future version")
 	}
 
-	if serverMeasurements != "" && verifyTLS {
+	tdx.SetLogDcapQuote(cCtx.Bool("log-dcap-quote"))
+
+	return runClientFromConfig(log, config)
+}
+
+func runClientFromConfig(log *slog.Logger, config ClientConfig) error {
+	if config.ServerMeasurements != "" && config.VerifyTLS {
 		log.Error("invalid combination of --verify-tls and --server-measurements passed (cannot add server measurements and verify default TLS at the same time)")
 		return errors.New("invalid combination of --verify-tls and --server-measurements passed (cannot add server measurements and verify default TLS at the same time)")
 	}
 
-	clientAttestationType, err := proxy.ParseAttestationType(cCtx.String("client-attestation-type"))
+	clientAttestationType, err := proxy.ParseAttestationType(config.ClientAttestationType)
 	if err != nil {
-		log.With("attestation-type", cCtx.String("client-attestation-type")).Error("invalid client-attestation-type passed, see --help")
+		log.With("attestation-type", config.ClientAttestationType).Error("invalid client-attestation-type passed, see --help")
 		return err
 	}
 
@@ -116,49 +135,85 @@ func runClient(cCtx *cli.Context) error {
 		return err
 	}
 
-	validators, err := proxy.CreateAttestationValidatorsFromFile(log, serverMeasurements)
+	parsedMeasurements, err := proxy.LoadMeasurementsFromFile(log, config.ServerMeasurements)
 	if err != nil {
 		log.Error("could not create attestation validators from file", "err", err)
 		return err
 	}
 
-	tlsConfig, err := atls.CreateAttestationClientTLSConfig(issuer, validators)
-	if err != nil {
-		log.Error("could not create atls config", "err", err)
-		return err
-	}
-
-	if verifyTLS {
-		tlsConfig.InsecureSkipVerify = false
-		tlsConfig.ServerName = ""
-	}
-
-	if additionalTLSCA := cCtx.String("tls-ca-certificate"); additionalTLSCA != "" {
-		if !verifyTLS {
-			log.Error("--tls-ca-certificate specified but --verify-tls is not, refusing to continue")
-			return errors.New("--tls-ca-certificate specified but --verify-tls is not, refusing to continue")
-		}
-
-		certData, err := os.ReadFile(additionalTLSCA)
+	// Maps service tag (id) to list of measurements (ids). Should be passed in separately. For now assume single "default" service.
+	serviceMeasurements := map[proxy.ServiceTag][]multimeasurements.MeasurementsContainer{proxy.ServiceTag("default"): parsedMeasurements}
+	serviceValidators := make(map[proxy.ServiceTag][]atls.Validator)
+	for service, listOfMeasurements := range serviceMeasurements {
+		validators, err := proxy.CreateAttestationValidatorsFromMeasurements(log, listOfMeasurements)
 		if err != nil {
-			log.Error("could not read tls ca certificate data", "err", err)
+			return err
+		}
+		serviceValidators[service] = validators
+	}
+
+	proxyByService := make(map[proxy.ServiceTag]http.HandlerFunc)
+	for service, validators := range serviceValidators {
+		tlsConfig, err := atls.CreateAttestationClientTLSConfig(issuer, validators)
+		if err != nil {
+			log.Error("could not create atls config", "err", err)
 			return err
 		}
 
-		roots := x509.NewCertPool()
-		ok := roots.AppendCertsFromPEM(certData)
-		if !ok {
-			log.Error("invalid certificate received", "cert", string(certData))
-			return errors.New("invalid certificate")
+		if config.VerifyTLS {
+			tlsConfig.InsecureSkipVerify = false
+			tlsConfig.ServerName = ""
 		}
 
-		tlsConfig.RootCAs = roots
+		if additionalTLSCA := config.TLSCACertificate; additionalTLSCA != "" {
+			if !config.VerifyTLS {
+				log.Error("--tls-ca-certificate specified but --verify-tls is not, refusing to continue")
+				return errors.New("--tls-ca-certificate specified but --verify-tls is not, refusing to continue")
+			}
+
+			certData, err := os.ReadFile(additionalTLSCA)
+			if err != nil {
+				log.Error("could not read tls ca certificate data", "err", err)
+				return err
+			}
+
+			roots := x509.NewCertPool()
+			ok := roots.AppendCertsFromPEM(certData)
+			if !ok {
+				log.Error("invalid certificate received", "cert", string(certData))
+				return errors.New("invalid certificate")
+			}
+
+			tlsConfig.RootCAs = roots
+		}
+
+		var proxyHandler http.HandlerFunc
+		if config.TargetAddr == "from_header" {
+			rproxyFactory := func(targetURL *url.URL) *httputil.ReverseProxy {
+				rproxy := httputil.NewSingleHostReverseProxy(targetURL)
+				rproxy.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+				return rproxy
+			}
+			proxyHandler = proxy.NewDynamicHostReverseProxyFromHeader(log, validators, rproxyFactory)
+		} else {
+			rproxy := proxy.NewSingleHostReverseProxyFromUrl(log, validators, config.TargetAddr)
+			rproxy.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+			proxyHandler = proxy.NewProxy(log, rproxy.ServeHTTP, validators).ServeHTTP
+		}
+		proxyByService[service] = proxyHandler
 	}
 
-	proxyHandler := proxy.NewProxy(log, targetAddr, validators).WithTransport(&http.Transport{TLSClientConfig: tlsConfig})
+	var proxyHandler http.Handler
+	if len(proxyByService) == 1 {
+		for _, onlyProxy := range proxyByService {
+			proxyHandler = onlyProxy
+		}
+	} else {
+		proxyHandler = proxy.NewMultiServiceMiddleware(proxyByService)
+	}
 
-	log.With("listenAddr", listenAddr).Info("Starting proxy client")
-	err = http.ListenAndServe(listenAddr, proxyHandler)
+	log.With("listenAddr", config.ListenAddr).Info("Starting proxy client")
+	err = http.ListenAndServe(config.ListenAddr, proxyHandler)
 	if err != nil {
 		log.Error("stopping proxy", "server error", err)
 		return err

--- a/proxy/mutli_validator.go
+++ b/proxy/mutli_validator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/flashbots/cvm-reverse-proxy/internal/atls"
 )
 
-// MultiValidator is a validator for Azure confidential VM attestation using TDX which accepts multiple measurements
+// MultiValidator is a validator which accepts multiple measurements for the same type of attestation
 type MultiValidator struct {
 	oid        asn1.ObjectIdentifier
 	validators []atls.Validator
@@ -15,6 +15,11 @@ type MultiValidator struct {
 
 // NewMultiValidator returns a new Validator for Azure confidential VM attestation using TDX which accepts multiple measurements
 func NewMultiValidator(validators []atls.Validator) *MultiValidator {
+	if len(validators) == 0 {
+		// This is not an error! This is a bug!
+		panic("empty validators list passed in!")
+	}
+
 	for _, v := range validators {
 		if !v.OID().Equal(validators[0].OID()) {
 			// This is not an error! This is a bug!
@@ -25,6 +30,14 @@ func NewMultiValidator(validators []atls.Validator) *MultiValidator {
 		oid:        validators[0].OID(),
 		validators: validators,
 	}
+}
+
+func (v *MultiValidator) Append(nv atls.Validator) {
+	if !v.oid.Equal(nv.OID()) {
+		// This is not an error! This is a bug!
+		panic("validators with mismatching OIDs passed in!")
+	}
+	v.validators = append(v.validators, nv)
 }
 
 func (v *MultiValidator) OID() asn1.ObjectIdentifier {


### PR DESCRIPTION
Shows an idea rather than an implementation, enabling these features would most likely come from a new binary.
See https://github.com/flashbots/cvm-reverse-proxy/pull/39/files#diff-1d74870266949f1927a500e5f0002617239d3e3cd9bcceee6be014738e5e0f2bR82-R167